### PR TITLE
Update dockerfile to manually install unminimize

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,12 @@ FROM ubuntu:noble
 ARG TZ=America/New_York
 ENV TZ=${TZ}
 
+RUN apt-get update &&\
+    apt-get -y install curl
+
+RUN curl -o unminimize.deb http://launchpadlibrarian.net/740927514/unminimize_0.2.1_amd64.deb &&\
+    dpkg -i unminimize.deb
+
 # include manual pages and documentation
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update &&\

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -4,6 +4,12 @@ FROM ubuntu:noble
 ARG TZ=America/New_York
 ENV TZ=${TZ}
 
+RUN apt-get update &&\
+    apt-get -y install curl
+
+RUN curl -o unminimize.deb http://launchpadlibrarian.net/740927520/unminimize_0.2.1_arm64.deb &&\
+    dpkg -i unminimize.deb
+
 # include manual pages and documentation
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update &&\


### PR DESCRIPTION
I have several students reporting that the current Dockerfile cannot be build because of the following error:

> /bin/sh: 1: unminimize: not found 

While Ubuntu is suppose to have this command install built-in, the `ubuntu:nobel` image does not have this command (I verified by building the docker without the `unminimize` command and then try to invoke `unminimize` myself inside the docker container). So I updated the Dockerfile (and also the arm64 version of the Dockerfile) to first manually download the installation file for `unminimize`, install it and then run the rest of the command. 

This is probably a temporary bug so I am not sure if it is worth merging into the main branch. I figured I should create a pull requst anyway. 